### PR TITLE
Allow shift left operator take precedence over plus

### DIFF
--- a/Evt/Evt.py
+++ b/Evt/Evt.py
@@ -89,7 +89,7 @@ class SID_IDENTIFIER_AUTHORITY(Block, Nestable):
         return SID_IDENTIFIER_AUTHORITY.structure_size(self._buf, self.absolute_offset(0x0), None)
 
     def __str__(self):
-        return "%s" % (self.high_part() << 32 + self.low_part())
+        return "%s" % ((self.high_part() << 32) + self.low_part())
 
 
 class SID(Block, Nestable):


### PR DESCRIPTION
This allows proper calculations. Had the error, where a thread completely blocked because it tried to calculate
```
22722 << 32 + 163545272
```
and hung up while calculating this large number whereas
```
(22722 << 32) + 163545272
```
would return quickly and raise an exception later, which is better.
